### PR TITLE
[YAF-43] Tuist scaffold 데모앱이 없는 프로젝트 생성 자동화

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,11 +11,11 @@ CURRENT_DATE = $(shell pipenv run python Scripts/current_date.py)
 #	--current-date "$(CURRENT_DATE)";
 #	@rm Pipfile >/dev/null 2>&1;
 #	@tuist edit
-	
-NOAPP_FLAG := $(filter -noapp,$(MAKEFLAGS))
-	
+
+noapp ?= false
+
 Feature:
-ifeq ($(NOAPP_FLAG), -noapp)
+ifeq ($(noapp), true)
 	@mkdir -p Projects/Feature/${name};
 	@tuist scaffold FeatureWithoutExample \
 	--name ${name} \

--- a/Makefile
+++ b/Makefile
@@ -16,16 +16,14 @@ NOAPP_FLAG := $(filter -noapp,$(MAKEFLAGS))
 	
 Feature:
 ifeq ($(NOAPP_FLAG), -noapp)
-	@echo "feature project without example app"
 	@mkdir -p Projects/Feature/${name};
-	@tuist scaffold Feature \
+	@tuist scaffold FeatureWithoutExample \
 	--name ${name} \
 	--author "$(USER_NAME)" \
 	--current-date "$(CURRENT_DATE)";
 else
-	@echo "feature project with example app"
 	@mkdir -p Projects/Feature/${name};
-	@tuist scaffold FeatureWithoutApp \
+	@tuist scaffold Feature \
 	--name ${name} \
 	--author "$(USER_NAME)" \
 	--current-date "$(CURRENT_DATE)";

--- a/Makefile
+++ b/Makefile
@@ -3,11 +3,32 @@ USER_NAME = $(shell python3 Scripts/author_name.py)
 CURRENT_DATE = $(shell pipenv run python Scripts/current_date.py)
 
 
+#Feature:
+#	@mkdir -p Projects/Feature/${name};
+#	@tuist scaffold Feature \
+#	--name ${name} \
+#	--author "$(USER_NAME)" \
+#	--current-date "$(CURRENT_DATE)";
+#	@rm Pipfile >/dev/null 2>&1;
+#	@tuist edit
+	
+NOAPP_FLAG := $(filter -noapp,$(MAKEFLAGS))
+	
 Feature:
+ifeq ($(NOAPP_FLAG), -noapp)
+	@echo "feature project without example app"
 	@mkdir -p Projects/Feature/${name};
 	@tuist scaffold Feature \
 	--name ${name} \
 	--author "$(USER_NAME)" \
 	--current-date "$(CURRENT_DATE)";
+else
+	@echo "feature project with example app"
+	@mkdir -p Projects/Feature/${name};
+	@tuist scaffold FeatureWithoutApp \
+	--name ${name} \
+	--author "$(USER_NAME)" \
+	--current-date "$(CURRENT_DATE)";
+endif
 	@rm Pipfile >/dev/null 2>&1;
 	@tuist edit

--- a/Tuist/Scaffold/FeatureWithoutExample/Feature/Sources/ViewController.swift
+++ b/Tuist/Scaffold/FeatureWithoutExample/Feature/Sources/ViewController.swift
@@ -1,0 +1,11 @@
+//
+//  SampleViewController.swift
+//  ProjectDescriptionHelpers
+//
+//
+
+import UIKit
+
+class SampleViewController: UIViewController {
+
+}

--- a/Tuist/Scaffold/FeatureWithoutExample/Project.stencil
+++ b/Tuist/Scaffold/FeatureWithoutExample/Project.stencil
@@ -1,0 +1,41 @@
+//
+//  Project.swift
+//
+//  Created by {{ author }} on {{ currentDate }}
+//
+
+import ProjectDescription
+import DependencyPlugin
+
+let project = Project(
+    name: "{{ name }}",
+    targets: [
+
+        // Tests
+        .target(
+            name: "Feature{{ name }}Tests",
+            destinations: .iOS,
+            product: .unitTests,
+            bundleId: Project.Environment.bundleId(suffix: "feature.{{ name }}.tests"),
+            deploymentTargets: Project.Environment.deploymentTarget,
+            sources: ["Tests/**"],
+            dependencies: [
+                .feature(implements: .{{ name }}),
+            ]
+        ),
+
+
+        // Feature
+        .target(
+            name: "Feature{{ name }}",
+            destinations: .iOS,
+            product: .staticFramework,
+            bundleId: Project.Environment.bundleId(suffix: "feature.{{ name }}"),
+            deploymentTargets: Project.Environment.deploymentTarget,
+            sources: ["Feature/Sources/**"],
+            dependencies: [
+                
+            ]
+        ),
+    ]
+)

--- a/Tuist/Scaffold/FeatureWithoutExample/Tests/Tests.swift
+++ b/Tuist/Scaffold/FeatureWithoutExample/Tests/Tests.swift
@@ -1,0 +1,6 @@
+//
+//  Tests.swift
+//
+//
+
+import Foundation

--- a/Tuist/Templates/Feature/FeatureWithoutApp.swift
+++ b/Tuist/Templates/Feature/FeatureWithoutApp.swift
@@ -1,0 +1,41 @@
+//
+//  Templates/Feature.swift
+//
+//
+
+import Foundation
+import ProjectDescription
+
+private let name: Template.Attribute = .required("name")
+private let author: Template.Attribute = .required("author")
+private let currentDate: Template.Attribute = .required("currentDate")
+
+let projectPath = "Projects/Feature/\(name)"
+
+let featureTemplate = Template(
+    description: "A template for a new feature module",
+    attributes: [
+        name,
+        author,
+        currentDate
+    ],
+    items: [
+        
+        // MARK: Tests target
+        
+        .item(path: "\(projectPath)/Tests/Tests.swift", contents: .file(.relativeToRoot("Tuist/Scaffold/Feature/Tests/Tests.swift"))),
+        
+        
+        // MARK: Feature target
+        
+        .item(path: "\(projectPath)/Feature", contents: .directory(.relativeToRoot("Tuist/Scaffold/Feature/Feature/Sources"))),
+            
+    
+        // MARK: Project.swift
+        
+        .file(
+            path: "\(projectPath)/Project.swift",
+            templatePath: .relativeToRoot("Tuist/Scaffold/Feature/Project.stencil")
+        ),
+    ]
+)

--- a/Tuist/Templates/FeatureWithoutExample/FeatureWithoutExample.swift
+++ b/Tuist/Templates/FeatureWithoutExample/FeatureWithoutExample.swift
@@ -13,7 +13,7 @@ private let currentDate: Template.Attribute = .required("currentDate")
 let projectPath = "Projects/Feature/\(name)"
 
 let featureTemplate = Template(
-    description: "A template for a new feature module",
+    description: "A template for a new feature module without example",
     attributes: [
         name,
         author,
@@ -23,19 +23,19 @@ let featureTemplate = Template(
         
         // MARK: Tests target
         
-        .item(path: "\(projectPath)/Tests/Tests.swift", contents: .file(.relativeToRoot("Tuist/Scaffold/Feature/Tests/Tests.swift"))),
+        .item(path: "\(projectPath)/Tests/Tests.swift", contents: .file(.relativeToRoot("Tuist/Scaffold/FeatureWithoutExample/Tests/Tests.swift"))),
         
         
         // MARK: Feature target
         
-        .item(path: "\(projectPath)/Feature", contents: .directory(.relativeToRoot("Tuist/Scaffold/Feature/Feature/Sources"))),
+        .item(path: "\(projectPath)/Feature", contents: .directory(.relativeToRoot("Tuist/Scaffold/FeatureWithoutExample/Feature/Sources"))),
             
     
         // MARK: Project.swift
         
         .file(
             path: "\(projectPath)/Project.swift",
-            templatePath: .relativeToRoot("Tuist/Scaffold/Feature/Project.stencil")
+            templatePath: .relativeToRoot("Tuist/Scaffold/FeatureWithoutExample/Project.stencil")
         ),
     ]
 )


### PR DESCRIPTION
## 변경된 점

예시앱이 없는 Feature를 생성할 수 있도록 했습니다.

- 예시앱이 있는 경우(기존과 동일)

```bash
$ make Feature name=Sample
```

- 예시앱이 없는 경우

`noapp`변수의 값을 수정하면 됩니다.

```bash
$ make Feature name=Sample noapp=true
```