### PR TITLE
[YAF-56] 온보딩 유저 성별 입력 UI

### DIFF
--- a/Projects/Feature/Onboarding/Feature/Sources/InputGender/InputGenderBuilder.swift
+++ b/Projects/Feature/Onboarding/Feature/Sources/InputGender/InputGenderBuilder.swift
@@ -1,0 +1,39 @@
+//
+//  InputGenderBuilder.swift
+//  FeatureOnboarding
+//
+//  Created by choijunios on 1/7/25.
+//
+
+import RIBs
+
+protocol InputGenderDependency: Dependency {
+    // TODO: Declare the set of dependencies required by this RIB, but cannot be
+    // created by this RIB.
+}
+
+final class InputGenderComponent: Component<InputGenderDependency> {
+
+    // TODO: Declare 'fileprivate' dependencies that are only used by this RIB.
+}
+
+// MARK: - Builder
+
+protocol InputGenderBuildable: Buildable {
+    func build(withListener listener: InputGenderListener) -> InputGenderRouting
+}
+
+final class InputGenderBuilder: Builder<InputGenderDependency>, InputGenderBuildable {
+
+    override init(dependency: InputGenderDependency) {
+        super.init(dependency: dependency)
+    }
+
+    func build(withListener listener: InputGenderListener) -> InputGenderRouting {
+        let component = InputGenderComponent(dependency: dependency)
+        let viewController = InputGenderViewController()
+        let interactor = InputGenderInteractor(presenter: viewController)
+        interactor.listener = listener
+        return InputGenderRouter(interactor: interactor, viewController: viewController)
+    }
+}

--- a/Projects/Feature/Onboarding/Feature/Sources/InputGender/InputGenderInteractor.swift
+++ b/Projects/Feature/Onboarding/Feature/Sources/InputGender/InputGenderInteractor.swift
@@ -12,9 +12,14 @@ protocol InputGenderRouting: ViewableRouting {
     // TODO: Declare methods the interactor can invoke to manage sub-tree via the router.
 }
 
+enum InputGenderInteractorAction {
+    case updateButtonState(isEnabled: Bool)
+}
+
 protocol InputGenderPresentable: Presentable {
     var listener: InputGenderPresentableListener? { get set }
-    // TODO: Declare methods the interactor can invoke the presenter to present data.
+
+    func action(_ action: InputGenderInteractorAction)
 }
 
 protocol InputGenderListener: AnyObject {
@@ -25,6 +30,11 @@ final class InputGenderInteractor: PresentableInteractor<InputGenderPresentable>
 
     weak var router: InputGenderRouting?
     weak var listener: InputGenderListener?
+    
+    
+    // State
+    private(set) var state: State = .init()
+    
 
     // TODO: Add additional dependencies to constructor. Do not perform any logic
     // in constructor.
@@ -36,10 +46,44 @@ final class InputGenderInteractor: PresentableInteractor<InputGenderPresentable>
     override func didBecomeActive() {
         super.didBecomeActive()
         // TODO: Implement business logic here.
+        
+        presenter.action(.updateButtonState(isEnabled: false))
     }
 
     override func willResignActive() {
         super.willResignActive()
         // TODO: Pause any business logic.
+    }
+}
+
+
+// MARK: Data model
+extension InputGenderInteractor {
+    
+    struct State {
+        var gender: Gender? = nil
+    }
+}
+
+
+// MARK: InputGenderPresentableListener
+extension InputGenderInteractor {
+    
+    func request(_ request: InputGenderPresenterRequest) {
+        
+        switch request {
+        case .updateSelectedGender(let gender):
+            
+            state.gender = gender
+            
+            let buttonIsEnabled = (gender != nil)
+            
+            presenter.action(.updateButtonState(isEnabled: buttonIsEnabled))
+            
+        case .confirmCurrentGender:
+            print("confirm gender")
+        case .exitPage:
+            print("exit page")
+        }
     }
 }

--- a/Projects/Feature/Onboarding/Feature/Sources/InputGender/InputGenderInteractor.swift
+++ b/Projects/Feature/Onboarding/Feature/Sources/InputGender/InputGenderInteractor.swift
@@ -1,0 +1,45 @@
+//
+//  InputGenderInteractor.swift
+//  FeatureOnboarding
+//
+//  Created by choijunios on 1/7/25.
+//
+
+import RIBs
+import RxSwift
+
+protocol InputGenderRouting: ViewableRouting {
+    // TODO: Declare methods the interactor can invoke to manage sub-tree via the router.
+}
+
+protocol InputGenderPresentable: Presentable {
+    var listener: InputGenderPresentableListener? { get set }
+    // TODO: Declare methods the interactor can invoke the presenter to present data.
+}
+
+protocol InputGenderListener: AnyObject {
+    // TODO: Declare methods the interactor can invoke to communicate with other RIBs.
+}
+
+final class InputGenderInteractor: PresentableInteractor<InputGenderPresentable>, InputGenderInteractable, InputGenderPresentableListener {
+
+    weak var router: InputGenderRouting?
+    weak var listener: InputGenderListener?
+
+    // TODO: Add additional dependencies to constructor. Do not perform any logic
+    // in constructor.
+    override init(presenter: InputGenderPresentable) {
+        super.init(presenter: presenter)
+        presenter.listener = self
+    }
+
+    override func didBecomeActive() {
+        super.didBecomeActive()
+        // TODO: Implement business logic here.
+    }
+
+    override func willResignActive() {
+        super.willResignActive()
+        // TODO: Pause any business logic.
+    }
+}

--- a/Projects/Feature/Onboarding/Feature/Sources/InputGender/InputGenderInteractor.swift
+++ b/Projects/Feature/Onboarding/Feature/Sources/InputGender/InputGenderInteractor.swift
@@ -46,8 +46,6 @@ final class InputGenderInteractor: PresentableInteractor<InputGenderPresentable>
     override func didBecomeActive() {
         super.didBecomeActive()
         // TODO: Implement business logic here.
-        
-        presenter.action(.updateButtonState(isEnabled: false))
     }
 
     override func willResignActive() {
@@ -72,12 +70,15 @@ extension InputGenderInteractor {
     func request(_ request: InputGenderPresenterRequest) {
         
         switch request {
+        case .viewDidLoad:
+            
+            presenter.action(.updateButtonState(isEnabled: false))
+            
         case .updateSelectedGender(let gender):
             
             state.gender = gender
             
             let buttonIsEnabled = (gender != nil)
-            
             presenter.action(.updateButtonState(isEnabled: buttonIsEnabled))
             
         case .confirmCurrentGender:

--- a/Projects/Feature/Onboarding/Feature/Sources/InputGender/InputGenderRouter.swift
+++ b/Projects/Feature/Onboarding/Feature/Sources/InputGender/InputGenderRouter.swift
@@ -1,0 +1,26 @@
+//
+//  InputGenderRouter.swift
+//  FeatureOnboarding
+//
+//  Created by choijunios on 1/7/25.
+//
+
+import RIBs
+
+protocol InputGenderInteractable: Interactable {
+    var router: InputGenderRouting? { get set }
+    var listener: InputGenderListener? { get set }
+}
+
+protocol InputGenderViewControllable: ViewControllable {
+    // TODO: Declare methods the router invokes to manipulate the view hierarchy.
+}
+
+final class InputGenderRouter: ViewableRouter<InputGenderInteractable, InputGenderViewControllable>, InputGenderRouting {
+
+    // TODO: Constructor inject child builder protocols to allow building children.
+    override init(interactor: InputGenderInteractable, viewController: InputGenderViewControllable) {
+        super.init(interactor: interactor, viewController: viewController)
+        interactor.router = self
+    }
+}

--- a/Projects/Feature/Onboarding/Feature/Sources/InputGender/InputGenderViewController.swift
+++ b/Projects/Feature/Onboarding/Feature/Sources/InputGender/InputGenderViewController.swift
@@ -11,6 +11,7 @@ import UIKit
 
 enum InputGenderPresenterRequest {
     
+    case viewDidLoad
     case updateSelectedGender(Gender?)
     case confirmCurrentGender
     case exitPage
@@ -34,6 +35,12 @@ final class InputGenderViewController: UIViewController, InputGenderPresentable,
         self.mainView = mainView
         self.view = mainView
         mainView.listener = self
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        listener?.request(.viewDidLoad)
     }
 }
 

--- a/Projects/Feature/Onboarding/Feature/Sources/InputGender/InputGenderViewController.swift
+++ b/Projects/Feature/Onboarding/Feature/Sources/InputGender/InputGenderViewController.swift
@@ -15,7 +15,29 @@ protocol InputGenderPresentableListener: AnyObject {
     // interactor class.
 }
 
-final class InputGenderViewController: UIViewController, InputGenderPresentable, InputGenderViewControllable {
+final class InputGenderViewController: UIViewController, InputGenderPresentable, InputGenderViewControllable, InputGenderViewListener {
 
     weak var listener: InputGenderPresentableListener?
+    
+    override func loadView() {
+        
+        let mainView = InputGenderView()
+        self.view = mainView
+        mainView.listener = self
+    }
+}
+
+
+// MARK: InputGenderViewListener
+extension InputGenderViewController {
+    
+    func action(_ action: InputGenderView.Request) {
+        
+        //
+    }
+}
+
+
+#Preview {
+    InputGenderViewController()
 }

--- a/Projects/Feature/Onboarding/Feature/Sources/InputGender/InputGenderViewController.swift
+++ b/Projects/Feature/Onboarding/Feature/Sources/InputGender/InputGenderViewController.swift
@@ -9,10 +9,17 @@ import RIBs
 import RxSwift
 import UIKit
 
+enum InputGenderPresenterRequest {
+    
+    case updateSelectedGender(Gender)
+    case confirmCurrentGender
+    case exitPage
+}
+
+
 protocol InputGenderPresentableListener: AnyObject {
-    // TODO: Declare properties and methods that the view controller can invoke to perform
-    // business logic, such as signIn(). This protocol is implemented by the corresponding
-    // interactor class.
+    
+    func request(_ request: InputGenderPresenterRequest)
 }
 
 final class InputGenderViewController: UIViewController, InputGenderPresentable, InputGenderViewControllable, InputGenderViewListener {
@@ -31,9 +38,19 @@ final class InputGenderViewController: UIViewController, InputGenderPresentable,
 // MARK: InputGenderViewListener
 extension InputGenderViewController {
     
-    func action(_ action: InputGenderView.Request) {
+    func action(_ action: InputGenderView.Action) {
         
-        //
+        switch action {
+            
+        case .selectedGender(let gender):
+            listener?.request(.updateSelectedGender(gender))
+            
+        case .backButtonClicked:
+            listener?.request(.exitPage)
+            
+        case .confirmButtonClicked:
+            listener?.request(.confirmCurrentGender)
+        }
     }
 }
 

--- a/Projects/Feature/Onboarding/Feature/Sources/InputGender/InputGenderViewController.swift
+++ b/Projects/Feature/Onboarding/Feature/Sources/InputGender/InputGenderViewController.swift
@@ -1,0 +1,21 @@
+//
+//  InputGenderViewController.swift
+//  FeatureOnboarding
+//
+//  Created by choijunios on 1/7/25.
+//
+
+import RIBs
+import RxSwift
+import UIKit
+
+protocol InputGenderPresentableListener: AnyObject {
+    // TODO: Declare properties and methods that the view controller can invoke to perform
+    // business logic, such as signIn(). This protocol is implemented by the corresponding
+    // interactor class.
+}
+
+final class InputGenderViewController: UIViewController, InputGenderPresentable, InputGenderViewControllable {
+
+    weak var listener: InputGenderPresentableListener?
+}

--- a/Projects/Feature/Onboarding/Feature/Sources/InputGender/InputGenderViewController.swift
+++ b/Projects/Feature/Onboarding/Feature/Sources/InputGender/InputGenderViewController.swift
@@ -11,7 +11,7 @@ import UIKit
 
 enum InputGenderPresenterRequest {
     
-    case updateSelectedGender(Gender)
+    case updateSelectedGender(Gender?)
     case confirmCurrentGender
     case exitPage
 }
@@ -26,9 +26,12 @@ final class InputGenderViewController: UIViewController, InputGenderPresentable,
 
     weak var listener: InputGenderPresentableListener?
     
+    private(set) var mainView: InputGenderView!
+    
     override func loadView() {
         
         let mainView = InputGenderView()
+        self.mainView = mainView
         self.view = mainView
         mainView.listener = self
     }
@@ -50,6 +53,20 @@ extension InputGenderViewController {
             
         case .confirmButtonClicked:
             listener?.request(.confirmCurrentGender)
+        }
+    }
+}
+
+
+// MARK: InputGenderPresentable, 인터렉터가 전달하는 액션
+extension InputGenderViewController {
+    
+    func action(_ action: InputGenderInteractorAction) {
+        
+        switch action {
+        case .updateButtonState(let isEnabled):
+            
+            mainView.updateCtaButton(isEnabled: isEnabled)
         }
     }
 }

--- a/Projects/Feature/Onboarding/Feature/Sources/InputGender/Model/Gender.swift
+++ b/Projects/Feature/Onboarding/Feature/Sources/InputGender/Model/Gender.swift
@@ -1,0 +1,21 @@
+//
+//  Gender.swift
+//  FeatureOnboarding
+//
+//  Created by choijunios on 1/7/25.
+//
+
+enum Gender {
+    
+    case male
+    case female
+    
+    var displayingName: String {
+        switch self {
+        case .male:
+            "남성"
+        case .female:
+            "여성"
+        }
+    }
+}

--- a/Projects/Feature/Onboarding/Feature/Sources/InputGender/Views/Component/DSBoxButton.swift
+++ b/Projects/Feature/Onboarding/Feature/Sources/InputGender/Views/Component/DSBoxButton.swift
@@ -1,0 +1,181 @@
+//
+//  DSBoxButton.swift
+//  FeatureOnboarding
+//
+//  Created by choijunios on 1/7/25.
+//
+
+import UIKit
+
+import FeatureResources
+
+import Then
+import SnapKit
+
+final public class DSBoxButton: UIView {
+    
+    // Sub view
+    private let titleLabel: UILabel = .init()
+    
+    
+    // State
+    private var buttonState: ButtonState
+    
+    
+    public override var intrinsicContentSize: CGSize {
+        .init(width: UIView.noIntrinsicMetric, height: 148)
+    }
+    
+    
+    public init(buttonState: ButtonState = .idle) {
+        
+        self.buttonState = buttonState
+        
+        super.init(frame: .zero)
+        
+        setupUI()
+        setupLayout()
+    }
+    public required init?(coder: NSCoder) { nil }
+    
+    
+    @discardableResult
+    public func update(title: TitleState) -> Self {
+        
+        var titleText: String = ""
+        
+        switch title {
+        case .none:
+            titleText = ""
+        case .normal(let string):
+            titleText = string
+        }
+        
+        switch buttonState {
+        case .idle:
+            
+            titleLabel.do {
+                $0.displayText = titleText.displayText(
+                    font: .heading2SemiBold,
+                    color: R.Color.white100
+                )
+            }
+            
+        case .selected:
+            
+            titleLabel.do {
+                $0.displayText = titleText.displayText(
+                    font: .heading2SemiBold,
+                    color: R.Color.submain
+                )
+            }
+        }
+        
+        return self
+    }
+    
+    
+    @discardableResult
+    public func update(state: ButtonState) -> Self {
+        
+        self.buttonState = state
+        
+        let currentTitleText = titleLabel.displayText?.string
+        
+        switch buttonState {
+        case .idle:
+            
+            // background
+            self.backgroundColor = R.Color.gray800
+            self.layer.borderWidth = 1
+            self.layer.borderColor = R.Color.gray600.cgColor
+            
+            // text
+            if let currentTitleText {
+                
+                titleLabel.do {
+                    $0.displayText = currentTitleText.displayText(
+                        font: .heading2SemiBold,
+                        color: R.Color.white100
+                    )
+                }
+            }
+            
+        case .selected:
+            
+            // background
+            self.backgroundColor = R.Color.main10.withAlphaComponent(0.1)
+            self.layer.borderWidth = 1
+            self.layer.borderColor = R.Color.main40.withAlphaComponent(0.4).cgColor
+            
+            if let currentTitleText {
+                
+                titleLabel.do {
+                    $0.displayText = currentTitleText.displayText(
+                        font: .heading2SemiBold,
+                        color: R.Color.submain
+                    )
+                }
+            }
+        }
+        
+        return self
+    }
+}
+
+
+// MARK: View configuration
+public extension DSBoxButton {
+    
+    enum ButtonState {
+        case idle
+        case selected
+    }
+    
+    
+    enum TitleState {
+        case none
+        case normal(String)
+    }
+}
+
+
+// MARK: Set up view
+private extension DSBoxButton {
+    
+    private func setupUI() {
+        
+        // self
+        self.layer.cornerRadius = 16
+        
+        
+        // title view
+        addSubview(titleLabel)
+    }
+    
+    
+    private func setupLayout() {
+        
+        // title view
+        titleLabel.snp.makeConstraints { make in
+            make.center.equalToSuperview()
+        }
+    }
+}
+
+
+// MARK: Previews
+#Preview("idle state", traits: .fixedLayout(width: 148, height: 148), body: {
+    
+    DSBoxButton()
+        .update(state: .idle)
+        .update(title: .normal("테스트 라벨"))
+})
+
+
+#Preview("selected state", traits: .fixedLayout(width: 148, height: 148), body: {
+    
+    DSBoxButton()
+        .update(state: .selected)
+        .update(title: .normal("테스트 라벨"))
+})

--- a/Projects/Feature/Onboarding/Feature/Sources/InputGender/Views/Component/DSBoxButton.swift
+++ b/Projects/Feature/Onboarding/Feature/Sources/InputGender/Views/Component/DSBoxButton.swift
@@ -12,7 +12,18 @@ import FeatureResources
 import Then
 import SnapKit
 
+public protocol DSBoxButtonListener: AnyObject {
+    
+    func action(_ action: DSBoxButton.Action)
+}
+
 final public class DSBoxButton: UIView {
+    
+    // View action
+    public enum Action {
+        case stateChanged(ButtonState)
+    }
+    
     
     // Sub view
     private let titleLabel: UILabel = .init()
@@ -20,6 +31,10 @@ final public class DSBoxButton: UIView {
     
     // State
     private var buttonState: ButtonState
+    
+    
+    // Listener
+    public weak var listener: DSBoxButtonListener?
     
     
     // gesture
@@ -43,9 +58,14 @@ final public class DSBoxButton: UIView {
     }
     public required init?(coder: NSCoder) { nil }
     
+}
+
+
+// MARK: Public interface
+public extension DSBoxButton {
     
     @discardableResult
-    public func update(title: TitleState) -> Self {
+    func update(title: TitleState) -> Self {
         
         var titleText: String = ""
         
@@ -71,10 +91,11 @@ final public class DSBoxButton: UIView {
     }
     
     
+    /// 해당매서드로 상태변경시 Listener에게 이벤트가 퍼블리싱 됩니다.
     @discardableResult
-    public func update(state: ButtonState) -> Self {
+    func update(state newState: ButtonState) -> Self {
         
-        self.buttonState = state
+        self.buttonState = newState
         
         switch buttonState {
         case .idle:
@@ -84,6 +105,7 @@ final public class DSBoxButton: UIView {
         }
         
         // publish event
+        listener?.action(.stateChanged(newState))
         
         return self
     }
@@ -103,7 +125,11 @@ public extension DSBoxButton {
         case none
         case normal(String)
     }
-    
+}
+
+
+// MARK: Button appearance
+private extension DSBoxButton {
     
     private enum ButtonAppearance {
         case `default`

--- a/Projects/Feature/Onboarding/Feature/Sources/InputGender/Views/Component/DSBoxButton.swift
+++ b/Projects/Feature/Onboarding/Feature/Sources/InputGender/Views/Component/DSBoxButton.swift
@@ -14,7 +14,7 @@ import SnapKit
 
 public protocol DSBoxButtonListener: AnyObject {
     
-    func action(_ action: DSBoxButton.Action)
+    func action(sender button: DSBoxButton, action: DSBoxButton.Action)
 }
 
 final public class DSBoxButton: UIView {
@@ -105,7 +105,7 @@ public extension DSBoxButton {
         }
         
         // publish event
-        listener?.action(.stateChanged(newState))
+        listener?.action(sender: self, action: .stateChanged(newState))
         
         return self
     }
@@ -216,6 +216,8 @@ private extension DSBoxButton {
         // title view
         titleLabel.snp.makeConstraints { make in
             make.center.equalToSuperview()
+            make.leading.greaterThanOrEqualToSuperview()
+            make.trailing.lessThanOrEqualToSuperview()
         }
     }
     

--- a/Projects/Feature/Onboarding/Feature/Sources/InputGender/Views/Component/PolicyAgreementLabel.swift
+++ b/Projects/Feature/Onboarding/Feature/Sources/InputGender/Views/Component/PolicyAgreementLabel.swift
@@ -1,0 +1,63 @@
+//
+//  PolicyAgreementLabel.swift
+//  FeatureOnboarding
+//
+//  Created by choijunios on 1/7/25.
+//
+
+import UIKit
+
+import FeatureResources
+
+final class PolicyAgreementLabel: UILabel {
+    
+    init() {
+        super.init(frame: .zero)
+        
+        setupText()
+    }
+    required init?(coder: NSCoder) { nil }
+    
+    private func setupText() {
+        
+        let baseText = "서비스 시작 시 이용약관 및 개인정보처리방침에 동의하게 됩니다."
+        
+        let attributes: [NSAttributedString.Key: Any] = [
+            .font: FeatureResourcesFontFamily.Pretendard.regular.font(size: 12),
+            .foregroundColor: R.Color.gray500,
+            .kern: -0.12,
+            .paragraphStyle: {
+                let paragraphStyle = NSMutableParagraphStyle()
+                paragraphStyle.alignment = .center
+                return paragraphStyle
+            }()
+        ]
+        
+        let attributedString: NSMutableAttributedString = .init(
+            string: baseText, attributes: attributes)
+        
+        
+        let underlineAttributes: [NSAttributedString.Key: Any] = [
+            .underlineStyle: NSUnderlineStyle.single.rawValue,
+        ]
+        
+        // Apply underline to "이용약관"
+        if let termsRange = baseText.range(of: "이용약관") {
+            let nsRange = NSRange(termsRange, in: baseText)
+            attributedString.addAttributes(underlineAttributes, range: nsRange)
+        }
+        
+        // Apply underline to "개인정보처리방침"
+        if let privacyRange = baseText.range(of: "개인정보처리방침") {
+            let nsRange = NSRange(privacyRange, in: baseText)
+            attributedString.addAttributes(underlineAttributes, range: nsRange)
+        }
+        
+        self.attributedText = attributedString
+    }
+}
+
+#Preview {
+    
+    PolicyAgreementLabel()
+}

--- a/Projects/Feature/Onboarding/Feature/Sources/InputGender/Views/InputGenderView.swift
+++ b/Projects/Feature/Onboarding/Feature/Sources/InputGender/Views/InputGenderView.swift
@@ -14,7 +14,7 @@ protocol InputGenderViewListener: AnyObject {
     func action(_ action: InputGenderView.Request)
 }
 
-final class InputGenderView: UIView, DSBoxButtonListener, DefaultCTAButtonListener {
+final class InputGenderView: UIView, DSBoxButtonListener, DefaultCTAButtonListener, OnBoardingNavBarViewListener {
     
     // View action
     enum Request {
@@ -79,6 +79,7 @@ private extension InputGenderView {
         
         // navigationBarView
         addSubview(navigationBar)
+        navigationBar.listener = self
         
         
         // title label
@@ -89,6 +90,8 @@ private extension InputGenderView {
         [maleButton, femaleButton].forEach {
             genderButtonStack.addArrangedSubview($0)
         }
+        maleButton.listener = self
+        femaleButton.listener = self
         addSubview(genderButtonStack)
         
         
@@ -96,6 +99,7 @@ private extension InputGenderView {
         [ctaButton, policyAgreementLabel].forEach {
             buttonAndTextStack.addArrangedSubview($0)
         }
+        ctaButton.listener = self
         addSubview(buttonAndTextStack)
     }
     
@@ -139,7 +143,35 @@ extension InputGenderView {
     
     func action(sender button: DSBoxButton, action: DSBoxButton.Action) {
         
-        //
+        switch action {
+        case .stateChanged(let buttonState):
+            
+            switch buttonState {
+            case .idle:
+                break
+            case .selected:
+                switch button {
+                case maleButton:
+                    
+                    // publish event
+                    listener?.action(.selectedGender(.male))
+                    
+                    // apply radio ui
+                    femaleButton.update(state: .idle, animated: true)
+                    
+                case femaleButton:
+                    
+                    // publish event
+                    listener?.action(.selectedGender(.female))
+                    
+                    // apply radio ui
+                    maleButton.update(state: .idle, animated: true)
+                    
+                default:
+                    fatalError()
+                }
+            }
+        }
     }
 }
 
@@ -148,6 +180,16 @@ extension InputGenderView {
 extension InputGenderView {
     
     func action(_ action: DefaultCTAButton.Action) {
+        
+        //
+    }
+}
+
+
+// MARK: OnBoardingNavBarViewListener
+extension InputGenderView {
+    
+    func action(_ action: OnBoardingNavBarView.Action) {
         
         //
     }

--- a/Projects/Feature/Onboarding/Feature/Sources/InputGender/Views/InputGenderView.swift
+++ b/Projects/Feature/Onboarding/Feature/Sources/InputGender/Views/InputGenderView.swift
@@ -1,0 +1,154 @@
+//
+//  InputGenderView.swift
+//  FeatureOnboarding
+//
+//  Created by choijunios on 1/7/25.
+//
+
+import UIKit
+
+import FeatureResources
+
+protocol InputGenderViewListener: AnyObject {
+    
+    func action(_ action: InputGenderView.Request)
+}
+
+final class InputGenderView: UIView, DSBoxButtonListener, DefaultCTAButtonListener {
+    
+    // View action
+    enum Request {
+        case selectedGender(Gender)
+    }
+    
+    
+    // Sub view
+    private let navigationBar = OnBoardingNavBarView()
+    private let titleLabel: UILabel = .init().then {
+        $0.displayText = "성별을 알려주세요".displayText(
+            font: .heading1SemiBold,
+            color: R.Color.white100
+        )
+    }
+    private let maleButton = DSBoxButton()
+        .update(state: .idle)
+        .update(title: .normal(Gender.male.displayingName))
+    private let femaleButton = DSBoxButton()
+        .update(state: .idle)
+        .update(title: .normal(Gender.female.displayingName))
+    private let genderButtonStack: UIStackView = .init().then {
+            $0.axis = .horizontal
+            $0.distribution = .fillEqually
+            $0.spacing = 16
+        }
+    private let ctaButton: DefaultCTAButton = .init(initialState: .active).then {
+        $0.update("다음")
+        $0.update(state: .inactive)
+    }
+    private let policyAgreementLabel = PolicyAgreementLabel()
+    private let buttonAndTextStack: UIStackView = .init().then {
+            $0.axis = .vertical
+            $0.distribution = .fill
+            $0.alignment = .fill
+            $0.spacing = 14
+        }
+    
+    
+    // Listener
+    weak var listener: InputGenderViewListener?
+    
+    
+    init() {
+        super.init(frame: .zero)
+        
+        setupUI()
+        setupLayout()
+    }
+    required init?(coder: NSCoder) { nil }
+}
+
+
+// MARK: Set up view
+private extension InputGenderView {
+    
+    func setupUI() {
+        
+        // self
+        self.backgroundColor = R.Color.gray900
+        
+        
+        // navigationBarView
+        addSubview(navigationBar)
+        
+        
+        // title label
+        addSubview(titleLabel)
+        
+        
+        // genderButtonStack
+        [maleButton, femaleButton].forEach {
+            genderButtonStack.addArrangedSubview($0)
+        }
+        addSubview(genderButtonStack)
+        
+        
+        // button and text
+        [ctaButton, policyAgreementLabel].forEach {
+            buttonAndTextStack.addArrangedSubview($0)
+        }
+        addSubview(buttonAndTextStack)
+    }
+    
+    
+    func setupLayout() {
+        
+        // navigationBar
+        addSubview(navigationBar)
+        navigationBar.snp.makeConstraints { make in
+            make.top.equalTo(safeAreaLayoutGuide)
+            make.horizontalEdges.equalTo(safeAreaLayoutGuide)
+        }
+        
+        
+        // titleLabel
+        titleLabel.snp.makeConstraints { make in
+            make.top.equalTo(navigationBar.snp.bottom).offset(38)
+            make.centerX.equalToSuperview()
+        }
+        
+        
+        // genderButtonStack
+        genderButtonStack.snp.makeConstraints { make in
+            make.top.equalTo(titleLabel.snp.bottom).offset(70)
+            make.horizontalEdges.equalTo(safeAreaLayoutGuide).inset(40)
+        }
+        
+        
+        // buttonAndTextStack
+        buttonAndTextStack.snp.makeConstraints { make in
+            
+            make.bottom.equalTo(safeAreaLayoutGuide).inset(10)
+            make.horizontalEdges.equalTo(safeAreaLayoutGuide).inset(20)
+        }
+    }
+}
+
+
+// MARK: DSBoxButtonListener
+extension InputGenderView {
+    
+    func action(sender button: DSBoxButton, action: DSBoxButton.Action) {
+        
+        //
+    }
+}
+
+
+// MARK: DefaultCTAButtonListener
+extension InputGenderView {
+    
+    func action(_ action: DefaultCTAButton.Action) {
+        
+        //
+    }
+}

--- a/Projects/Feature/Onboarding/Feature/Sources/InputGender/Views/InputGenderView.swift
+++ b/Projects/Feature/Onboarding/Feature/Sources/InputGender/Views/InputGenderView.swift
@@ -11,14 +11,16 @@ import FeatureResources
 
 protocol InputGenderViewListener: AnyObject {
     
-    func action(_ action: InputGenderView.Request)
+    func action(_ action: InputGenderView.Action)
 }
 
 final class InputGenderView: UIView, DSBoxButtonListener, DefaultCTAButtonListener, OnBoardingNavBarViewListener {
     
     // View action
-    enum Request {
+    enum Action {
         case selectedGender(Gender)
+        case confirmButtonClicked
+        case backButtonClicked
     }
     
     
@@ -181,7 +183,7 @@ extension InputGenderView {
     
     func action(_ action: DefaultCTAButton.Action) {
         
-        //
+        listener?.action(.confirmButtonClicked)
     }
 }
 
@@ -191,6 +193,6 @@ extension InputGenderView {
     
     func action(_ action: OnBoardingNavBarView.Action) {
         
-        //
+        listener?.action(.backButtonClicked)
     }
 }

--- a/Projects/Feature/Onboarding/Feature/Sources/InputGender/Views/InputGenderView.swift
+++ b/Projects/Feature/Onboarding/Feature/Sources/InputGender/Views/InputGenderView.swift
@@ -18,37 +18,37 @@ final class InputGenderView: UIView, DSBoxButtonListener, DefaultCTAButtonListen
     
     // View action
     enum Action {
-        case selectedGender(Gender)
+        case selectedGender(Gender?)
         case confirmButtonClicked
         case backButtonClicked
     }
     
     
     // Sub view
-    private let navigationBar = OnBoardingNavBarView()
-    private let titleLabel: UILabel = .init().then {
+    let navigationBar = OnBoardingNavBarView()
+    let titleLabel: UILabel = .init().then {
         $0.displayText = "성별을 알려주세요".displayText(
             font: .heading1SemiBold,
             color: R.Color.white100
         )
     }
-    private let maleButton = DSBoxButton()
+    let maleButton = DSBoxButton()
         .update(state: .idle)
         .update(title: .normal(Gender.male.displayingName))
-    private let femaleButton = DSBoxButton()
+    let femaleButton = DSBoxButton()
         .update(state: .idle)
         .update(title: .normal(Gender.female.displayingName))
-    private let genderButtonStack: UIStackView = .init().then {
+    let genderButtonStack: UIStackView = .init().then {
             $0.axis = .horizontal
             $0.distribution = .fillEqually
             $0.spacing = 16
         }
-    private let ctaButton: DefaultCTAButton = .init(initialState: .active).then {
+    let ctaButton: DefaultCTAButton = .init(initialState: .active).then {
         $0.update("다음")
         $0.update(state: .inactive)
     }
-    private let policyAgreementLabel = PolicyAgreementLabel()
-    private let buttonAndTextStack: UIStackView = .init().then {
+    let policyAgreementLabel = PolicyAgreementLabel()
+    let buttonAndTextStack: UIStackView = .init().then {
             $0.axis = .vertical
             $0.distribution = .fill
             $0.alignment = .fill
@@ -139,6 +139,15 @@ private extension InputGenderView {
     }
 }
 
+// MARK: public interface
+extension InputGenderView {
+    
+    func updateCtaButton(isEnabled: Bool) {
+        
+        ctaButton.update(state: isEnabled ? .active : .inactive)
+    }
+}
+
 
 // MARK: DSBoxButtonListener
 extension InputGenderView {
@@ -150,6 +159,10 @@ extension InputGenderView {
             
             switch buttonState {
             case .idle:
+                
+                // publish event
+                listener?.action(.selectedGender(nil))
+                
                 break
             case .selected:
                 switch button {

--- a/Projects/Feature/Onboarding/Feature/Sources/InputWakeUpAlarm/Views/CTAButton/DefaultCTAButton.swift
+++ b/Projects/Feature/Onboarding/Feature/Sources/InputWakeUpAlarm/Views/CTAButton/DefaultCTAButton.swift
@@ -11,15 +11,15 @@ import FeatureResources
 
 import SnapKit
 
-protocol DefaultCTAButtonListener: AnyObject {
+public protocol DefaultCTAButtonListener: AnyObject {
     
     func action(_ action: DefaultCTAButton.Action)
 }
 
-final class DefaultCTAButton: UIView {
+public final class DefaultCTAButton: UIView {
     
     // Action
-    enum Action {
+    public enum Action {
         case buttonIsTapped
     }
     
@@ -30,12 +30,12 @@ final class DefaultCTAButton: UIView {
     
     
     // Listener
-    weak var listener: DefaultCTAButtonListener?
+    public weak var listener: DefaultCTAButtonListener?
     
 
     // State
     private var state: State = .active
-    private var isEnabled: Bool { state == .active }
+    public var isEnabled: Bool { state == .active }
     
     
     // Gesture
@@ -46,13 +46,13 @@ final class DefaultCTAButton: UIView {
     private let baseFont: R.Font = .body1SemiBold
     
     
-    override var intrinsicContentSize: CGSize {
+    public override var intrinsicContentSize: CGSize {
         
         .init(width: UIView.noIntrinsicMetric, height: 54)
     }
     
     
-    init(initialState: State = .active) {
+    public init(initialState: State = .active) {
     
         super.init(frame: .zero)
         
@@ -62,7 +62,7 @@ final class DefaultCTAButton: UIView {
         setupLayout()
         setupTapGesture()
     }
-    required init?(coder: NSCoder) { nil }
+    public required init?(coder: NSCoder) { nil }
     
     
     private func setupUI() {
@@ -119,7 +119,7 @@ final class DefaultCTAButton: UIView {
 
 
 // MARK: Public interface
-extension DefaultCTAButton {
+public extension DefaultCTAButton {
     
     func update(_ text: String) {
         updateAppearance(text: text, state: self.state)
@@ -145,7 +145,7 @@ extension DefaultCTAButton {
 // MARK: State
 extension DefaultCTAButton {
     
-    enum State {
+    public enum State {
         case active
         case inactive
     }

--- a/Projects/Feature/Onboarding/Tests/InputGender/InputGenderRIBTests.swift
+++ b/Projects/Feature/Onboarding/Tests/InputGender/InputGenderRIBTests.swift
@@ -20,6 +20,7 @@ class InputGenderRIBTestCase: XCTestCase {
         let presenter = InputGenderViewController()
         let interactor = InputGenderInteractor(presenter: presenter)
         presenter.loadView()
+        presenter.viewDidLoad()
         XCTAssertFalse(presenter.mainView.ctaButton.isEnabled)
         
         // When

--- a/Projects/Feature/Onboarding/Tests/InputGender/InputGenderRIBTests.swift
+++ b/Projects/Feature/Onboarding/Tests/InputGender/InputGenderRIBTests.swift
@@ -1,0 +1,32 @@
+//
+//  InputGenderRIBTests.swift
+//  FeatureOnboarding
+//
+//  Created by choijunios on 1/7/25.
+//
+
+@testable import FeatureOnboarding
+
+import XCTest
+
+
+
+class InputGenderRIBTestCase: XCTestCase {
+    
+    
+    func test_buttonIsEnabled() {
+        
+        // Given
+        let presenter = InputGenderViewController()
+        let interactor = InputGenderInteractor(presenter: presenter)
+        presenter.loadView()
+        XCTAssertFalse(presenter.mainView.ctaButton.isEnabled)
+        
+        // When
+        presenter.action(.selectedGender(.male))
+        
+        
+        // Then
+        XCTAssertTrue(presenter.mainView.ctaButton.isEnabled)
+    }
+}

--- a/Projects/Feature/Resources/Feature/Sources/R.swift
+++ b/Projects/Feature/Resources/Feature/Sources/R.swift
@@ -10,6 +10,7 @@ public class R {
     }
     
     public struct Color {
+        public static let submain = UIColor(hex: "#FDFE96")
         public static let main100 = UIColor(hex: "#FEFF65")
         public static let main90 = main100.withAlphaComponent(90)
         public static let main80 = main100.withAlphaComponent(80)


### PR DESCRIPTION
## 변경된 점

- 온보딩 화면 Gender선택 UI 구현(+ 테스트 코드)
- 공용 컴포넌트 구현

### 온보딩 화면 Gender선택 UI 구현

온보딩 화면중 성별선택 화면의 UI를 구현했습니다.

성별을 선택시 버튼이 활성화 됨을 확인하기 위해 테스트 모듈에 단위 테스트 코드를 작성했습니다.

- 시현 영상(Preview)
<img src="https://github.com/user-attachments/assets/1ffb426a-de63-4be0-9b01-6688cc69e150" width=300 />

예시앱 코드가 작성된 브렌치 병합이후 해당 기능 및 알람 최초설정 화면을 예시앱에 추가하겠습니다!

### 공용 컴포넌트 작성

현재 브랜치에 디자인 시스템 프로젝트가 존재하지 않습니다, 따라서 해당 프로젝트가 존재하는 브렌치 병합이후 옮기는 작업을 할 계획입니다.

- DefaultCTAButton : public접근 지정자를 적용했습니다.
- DSBoxButton
- PolicyAgreementLabel : 개인정보 및 약관에 동의한다는 텍스트 입니다. 재사용하기 쉽게 만들어 뒀습니다.