### PR TITLE
[YAF-000] Fix, LineHeight에 기반한 베이스 라인 조정

### DIFF
--- a/Projects/Feature/Resources/Feature/Sources/Common/String+Extension.swift
+++ b/Projects/Feature/Resources/Feature/Sources/Common/String+Extension.swift
@@ -24,12 +24,19 @@ public extension String {
         let adjustedLetterSpacing = font.size * (font.letterSpacing / 100)
         let adjustedLineHeight = font.size * font.lineHeight
         let uiFont = font.toUIFont() ?? UIFont.systemFont(ofSize: font.size)
-//        let wordMinHeight = uiFont.ascender + abs(uiFont.descender)
-//        let baseLineOffset = (font.lineHeight-wordMinHeight)/2
+        
+        let paragraphStyle: NSMutableParagraphStyle = .init()
+        paragraphStyle.minimumLineHeight = adjustedLineHeight
+        paragraphStyle.maximumLineHeight = adjustedLineHeight
+        
+        let wordMinHeight = uiFont.ascender + abs(uiFont.descender)
+        let baseLineOffset = (adjustedLineHeight-wordMinHeight)/2
+        
         var attributes: [NSAttributedString.Key: Any] = [
             .font: uiFont,
             .kern: adjustedLetterSpacing, // 글자 간격
-            .paragraphStyle: toParagraphStyle(lineHeight: adjustedLineHeight),
+            .paragraphStyle: paragraphStyle,
+            .baselineOffset : baseLineOffset,
         ]
         if let color {
             attributes[.foregroundColor] = color


### PR DESCRIPTION
## 변경된 점

- 타이포 그래피 글자 베이스 라인 변경

### 타이포 그래피 글자 베이스 라인 변경

설정된 `lineHeight`에 대한 베이스 라인이 조정되지 않아 아래와 같이 레이아웃 상에 문제가 발생했습니다.

<img width="174" alt="스크린샷 2025-01-20 오후 9 56 01" src="https://github.com/user-attachments/assets/5ba4cc06-6068-4157-b981-5fece2eb4b66" />

`lineHeight`에 따른 글자의 베이스라인 조정 후

<img width="157" alt="스크린샷 2025-01-20 오후 9 56 58" src="https://github.com/user-attachments/assets/e4e78016-f0ce-46c7-9501-acfba28efb54" />

※ 변경이후 현재까지 개발된 UI를 점검해본 결과 특별한 문제는 발견하지 못했습니다.