### PR TITLE
[YAF-91] 흔들기 미션 화면 QA반영

### DIFF
--- a/Projects/Feature/AlarmMission/Feature/Sources/ShakeMission/Main/Views/ShakeMissionMainView.swift
+++ b/Projects/Feature/AlarmMission/Feature/Sources/ShakeMission/Main/Views/ShakeMissionMainView.swift
@@ -186,7 +186,7 @@ private extension ShakeMissionMainView {
         startMissionButton.setContentCompressionResistancePriority(.required, for: .vertical)
         startMissionButton.snp.makeConstraints { make in
             make.horizontalEdges.equalTo(self.safeAreaInsets).inset(20)
-            make.bottom.equalTo(rejectMissionButton.snp.top).offset(-8)
+            make.bottom.equalTo(rejectMissionButton.snp.top).offset(-22)
         }
         
         

--- a/Projects/Feature/AlarmMission/Feature/Sources/ShakeMission/Working/ShakeMissionWorkingViewController.swift
+++ b/Projects/Feature/AlarmMission/Feature/Sources/ShakeMission/Working/ShakeMissionWorkingViewController.swift
@@ -104,7 +104,7 @@ extension ShakeMissionWorkingViewController {
         case .hapticGeneratorAction(let action):
             switch action {
             case .prepare:
-                self.impactFeedBackGenerator = .init(style: .medium)
+                self.impactFeedBackGenerator = .init(style: .heavy)
                 self.impactFeedBackGenerator?.prepare()
             case .occur:
                 self.impactFeedBackGenerator?.impactOccurred()


### PR DESCRIPTION
## 변경된 점

- 메인화면 '미션하지 않기' 버튼 레이아웃 조정
- 흔들기 미션 진동 강화

### 흔들기 미션 진동 강화

`UIImpactFeedbackGenerator`스타일은 `medium`에서 `heavy`로 변경

### QA요청사항

- [x] <s>핸드폰 흔들릴 때만 카드가 좌우로 움직이게 하기</s>
    - 작업시간이 많이 소비될 것이라 생각해 MVP이후 진행하는 것으로 협의
- [x] 흔들기 미션 수행시 진동이 잘 느껴지지 않는 것 같습니다.
- [x] '미션하지  않기' UI 관련 이슈
    - 왼쪽 레이아웃을 오른쪽 레이아웃으로 조정