### PR TITLE
[YAF-131] 온보딩, 메인에서 알람 생성시 현재시간 반영

### DIFF
--- a/Projects/Feature/Alarm/Feature/Sources/Alarm/CreateEditAlarm/CreateAlarmInteractor.swift
+++ b/Projects/Feature/Alarm/Feature/Sources/Alarm/CreateEditAlarm/CreateAlarmInteractor.swift
@@ -58,10 +58,28 @@ final class CreateEditAlarmInteractor: PresentableInteractor<CreateEditAlarmPres
         self.mode = mode
         switch mode {
         case .create:
+            var hour = Hour(6)!
+            var minute = Minute(0)!
+            var meridiem: Meridiem = .am
+            let dateComponents = Calendar.current.dateComponents([.hour, .minute], from: .now)
+            
+            if let currentHour = dateComponents.hour {
+                if currentHour >= 12 {
+                    meridiem = .pm
+                }
+                if currentHour >= 13, let formatted = Hour(currentHour-12) {
+                    hour = formatted
+                } else if let formatted = Hour(currentHour) {
+                    hour = formatted
+                }
+            }
+            if let currentMinute = dateComponents.minute, let formatted = Minute(currentMinute) {
+                minute = formatted
+            }
             self.alarm = .init(
-                meridiem: .am,
-                hour: Hour(6)!,
-                minute: Minute(0)!,
+                meridiem: meridiem,
+                hour: hour,
+                minute: minute,
                 repeatDays: AlarmDays(days: []),
                 snoozeOption: SnoozeOption(isSnoozeOn: true, frequency: .fiveMinutes, count: .fiveTimes),
                 soundOption: SoundOption(isVibrationOn: true, isSoundOn: true, volume: 0.7, selectedSound:  R.AlarmSound.Marimba.title)

--- a/Projects/Feature/DesignSystem/Feature/Sources/Components/Picker/AlarmPicker/AlarmPickerColumnView.swift
+++ b/Projects/Feature/DesignSystem/Feature/Sources/Components/Picker/AlarmPicker/AlarmPickerColumnView.swift
@@ -41,7 +41,6 @@ final class AlarmPickerColumnView: UIView, UIScrollViewDelegate {
     // Observable
     fileprivate let changeContent: BehaviorRelay<Content?> = .init(value: nil)
     fileprivate let currentSelectedItem: BehaviorRelay<PickerSelectionItemable?> = .init(value: nil)
-    private let layoutSubViews: BehaviorSubject<Void?> = .init(value: nil)
     private let disposeBag = DisposeBag()
     
     override var intrinsicContentSize: CGSize {
@@ -66,13 +65,6 @@ final class AlarmPickerColumnView: UIView, UIScrollViewDelegate {
     }
     
     required init?(coder: NSCoder) { nil }
-    
-    
-    override func layoutSubviews() {
-        super.layoutSubviews()
-        
-        layoutSubViews.onNext(())
-    }
     
     
     private func setupUI() {
@@ -161,15 +153,11 @@ final class AlarmPickerColumnView: UIView, UIScrollViewDelegate {
     
     
     private func setReactive() {
-        
         // changeContent
-        Observable
-            .combineLatest(
-                changeContent.compactMap({ $0 }),
-                layoutSubViews.take(1)
-            )
+        changeContent
+            .compactMap({ $0 })
             .observe(on: MainScheduler.asyncInstance)
-            .subscribe(onNext: { [weak self] content, _ in
+            .subscribe(onNext: { [weak self] content in
                 guard let self else { return }
                     
                 scrollView.isScrollEnabled = false

--- a/Projects/Feature/DesignSystem/Feature/Sources/Components/Picker/AlarmPicker/AlarmPickerItemView.swift
+++ b/Projects/Feature/DesignSystem/Feature/Sources/Components/Picker/AlarmPicker/AlarmPickerItemView.swift
@@ -56,6 +56,7 @@ final class AlarmPickerItemView: UIView {
     func setContentSize(_ size: CGSize) -> Self {
         
         self.contentSize = size
+        self.invalidateIntrinsicContentSize()
         
         return self
     }

--- a/Projects/Feature/DesignSystem/Feature/Sources/Components/Picker/BirthDatePicker/BirthDatePickerColumnView.swift
+++ b/Projects/Feature/DesignSystem/Feature/Sources/Components/Picker/BirthDatePicker/BirthDatePickerColumnView.swift
@@ -45,7 +45,6 @@ final class BirthDatePickerColumnView: UIView, UIScrollViewDelegate {
     // Observable
     fileprivate let changeContent: BehaviorRelay<Content?> = .init(value: nil)
     fileprivate let currentSelectedContent: BehaviorRelay<Content?> = .init(value: nil)
-    private let layoutSubViews: BehaviorSubject<Void?> = .init(value: nil)
     private let disposeBag = DisposeBag()
     
     override var intrinsicContentSize: CGSize {
@@ -70,13 +69,6 @@ final class BirthDatePickerColumnView: UIView, UIScrollViewDelegate {
     }
     
     required init?(coder: NSCoder) { nil }
-    
-    
-    override func layoutSubviews() {
-        super.layoutSubviews()
-        
-        layoutSubViews.onNext(())
-    }
     
     
     private func setupUI() {
@@ -156,13 +148,9 @@ final class BirthDatePickerColumnView: UIView, UIScrollViewDelegate {
     private func setReactive() {
         
         // changeContent
-        Observable
-            .combineLatest(
-                changeContent.compactMap({ $0 }),
-                layoutSubViews.take(1)
-            )
+        changeContent.compactMap({ $0 })
             .observe(on: MainScheduler.asyncInstance)
-            .subscribe(onNext: { [weak self] content, _ in
+            .subscribe(onNext: { [weak self] content in
                 guard let self else { return }
                     
                 scrollView.isScrollEnabled = false

--- a/Projects/Feature/DesignSystem/Feature/Sources/Components/Picker/BirthDatePicker/BirthDatePickerItemView.swift
+++ b/Projects/Feature/DesignSystem/Feature/Sources/Components/Picker/BirthDatePicker/BirthDatePickerItemView.swift
@@ -26,9 +26,7 @@ public final class BirthDatePickerItemView: UIView {
     private var titleLabelConfig: TitleLabelConfig?
     
     
-    public override var intrinsicContentSize: CGSize {
-        return viewSize
-    }
+    public override var intrinsicContentSize: CGSize { viewSize }
     
     
     public init(content: String, viewSize: CGSize) {

--- a/Projects/Feature/Onboarding/Feature/Sources/InputBirthDate/Views/InputBirthDateView.swift
+++ b/Projects/Feature/Onboarding/Feature/Sources/InputBirthDate/Views/InputBirthDateView.swift
@@ -106,7 +106,7 @@ final class InputBirthDateView: UIView, OnBoardingNavBarViewListener, BirthDateP
         // navigationBar
         navigationBar.snp.makeConstraints { make in
             make.top.equalTo(safeAreaLayoutGuide.snp.top)
-            make.horizontalEdges.equalTo(safeAreaLayoutGuide.snp.horizontalEdges)
+            make.horizontalEdges.equalTo(safeAreaLayoutGuide)
         }
         
         
@@ -119,8 +119,8 @@ final class InputBirthDateView: UIView, OnBoardingNavBarViewListener, BirthDateP
         
         // birthDataPicker
         birthDatePicker.snp.makeConstraints { make in
-            make.top.equalTo(titleLabel.snp.bottom).inset(-69)
-            make.horizontalEdges.equalTo(self.safeAreaLayoutGuide.snp.horizontalEdges)
+            make.top.equalTo(titleLabel.snp.bottom).offset(69)
+            make.horizontalEdges.equalTo(safeAreaLayoutGuide)
                 .inset(20)
         }
         
@@ -132,10 +132,8 @@ final class InputBirthDateView: UIView, OnBoardingNavBarViewListener, BirthDateP
         
         // ctaButton
         ctaButton.snp.makeConstraints { make in
-            make.horizontalEdges.equalTo(self.safeAreaLayoutGuide.snp.horizontalEdges)
-                .inset(20)
-            make.bottom.equalTo(policyAgreementLabel.snp.top)
-                .offset(-12)
+            make.horizontalEdges.equalTo(safeAreaLayoutGuide).inset(20)
+            make.bottom.equalTo(policyAgreementLabel.snp.top).offset(-12)
         }
     }
 }

--- a/Projects/Feature/Onboarding/Feature/Sources/InputWakeUpAlarm/Views/InputWakeUpAlarmView.swift
+++ b/Projects/Feature/Onboarding/Feature/Sources/InputWakeUpAlarm/Views/InputWakeUpAlarmView.swift
@@ -152,6 +152,7 @@ extension InputWakeUpAlarmView {
 // MARK: AlarmPickerListener
 extension InputWakeUpAlarmView {
     func latestSelection(meridiem: Meridiem, hour: Hour, minute: Minute) {
+        self.layoutIfNeeded()
         listener?.action(.alarmPicker(meridiem, hour, minute))
     }
 }

--- a/Projects/Feature/Onboarding/Feature/Sources/Models/OnboardingModel.swift
+++ b/Projects/Feature/Onboarding/Feature/Sources/Models/OnboardingModel.swift
@@ -10,14 +10,36 @@ import FeatureCommonDependencies
 import FeatureResources
 
 public struct OnboardingModel {
-    public var alarm: Alarm = Alarm(
-        meridiem: .am,
-        hour: .init(6)!,
-        minute: .init(0)!,
-        repeatDays: AlarmDays(days: [.monday, .tuesday, .wednesday, .thursday, .friday]),
-        snoozeOption: .init(isSnoozeOn: true, frequency: .fiveMinutes, count: .fiveTimes),
-        soundOption: .init(isVibrationOn: true, isSoundOn: true, volume: 0.7, selectedSound: R.AlarmSound.Marimba.title)
-    )
+    public var alarm: Alarm = {
+        var hour = Hour(6)!
+        var minute = Minute(0)!
+        var meridiem: Meridiem = .am
+        let dateComponents = Calendar.current.dateComponents([.hour, .minute], from: .now)
+        
+        if let currentHour = dateComponents.hour {
+            if currentHour >= 12 {
+                meridiem = .pm
+            }
+            if currentHour >= 13, let formatted = Hour(currentHour-12) {
+                hour = formatted
+            } else if let formatted = Hour(currentHour) {
+                hour = formatted
+            }
+        }
+        if let currentMinute = dateComponents.minute, let formatted = Minute(currentMinute) {
+            minute = formatted
+        }
+        
+        let alarm = Alarm(
+            meridiem: meridiem,
+            hour: hour,
+            minute: minute,
+            repeatDays: AlarmDays(days: [.monday, .tuesday, .wednesday, .thursday, .friday]),
+            snoozeOption: .init(isSnoozeOn: true, frequency: .fiveMinutes, count: .fiveTimes),
+            soundOption: .init(isVibrationOn: true, isSoundOn: true, volume: 0.7, selectedSound: R.AlarmSound.Marimba.title)
+        )
+        return alarm
+    }()
     public var birthDate: BirthDateData = {
         let calendar = CalendarType.gregorian
         let year = Year(2000)


### PR DESCRIPTION
## 변경된 점

- 온보딩, 메인화면 알람생성시 현재시간 반영
- 알람, 생년월일 피커 내부로직 수정

### 온보딩, 메인화면 알람생성시 현재시간 반영

온보딩의 경우 `Root Interactor`(온보딩 내부)에서 최초로 `OnboardingModel`생성시 현재시간에 기반한 데이터가 생성되도록 수정

메인의 경우 `CreateAlarmRIB`의 인터렉터에서 해당 작업을 처리

※ 현재 두 공간에 중복코드

### 알람, 생년월일 피커 내부로직 수정

컨텐츠 사이즈 수정시 `invalidateIntrinsicContenSize`를 호출하여 제약 충돌 방지