### PR TITLE
Feat, 운세 미리 로드하고, 화면 호출 시 로드 안되어있으면 로딩 좀더 보여주다가 완료되면 화면전환되도록 수정

### DIFF
--- a/Projects/Feature/AlarmRelease/Feature/Sources/Root/RootInteractor.swift
+++ b/Projects/Feature/AlarmRelease/Feature/Sources/Root/RootInteractor.swift
@@ -47,6 +47,8 @@ public enum RootRouterRequest {
     case detachAlarmMission
     case routeToFortune(Fortune, UserInfo, FortuneSaveInfo)
     case detachFortune
+    case showLoading
+    case hideLoading
 }
 
 public protocol RootRouting: Routing {
@@ -67,11 +69,16 @@ final class RootInteractor: Interactor, RootInteractable {
     weak var listener: RootListener?
 
     private let fortunePublisher: PublishSubject<Result<Fortune, Error>> = .init()
+    private let userInfoPublisher: PublishSubject<Result<UserInfo, Error>> = .init()
     private let finishWithMissionComplete: PublishSubject<Bool> = .init()
     private let alarm: Alarm
     private let isFirstAlarm: Bool
     private let stream: ReleaseAlarmMutableStream
     private let logger: Logger
+    
+    // API 완료 상태 추적
+    private var isFortuneReady = false
+    private var isUserInfoReady = false
     init(
         alarm: Alarm,
         isFirstAlarm: Bool,
@@ -89,12 +96,8 @@ final class RootInteractor: Interactor, RootInteractable {
         
         bind()
         
-        // 운세 API요청
-        if let fortuneInfo = UserDefaults.standard.dailyFortune() {
-            getFortune(fortuneId: fortuneInfo.id)
-        } else {
-            createFortune()
-        }
+        // API 미리 로드 시작
+        preloadAPIs()
         
         router?.request(.routeToIntro)
     }
@@ -106,12 +109,47 @@ final class RootInteractor: Interactor, RootInteractable {
     
     private func bind() {
         let fortuneFetchedSuccess = fortunePublisher.compactMap({ $0.value })
+        let userInfoFetchedSuccess = userInfoPublisher.compactMap({ $0.value })
         
-        Observable.combineLatest(finishWithMissionComplete, fortuneFetchedSuccess)
+        // API 완료 상태 추적
+        fortuneFetchedSuccess
             .observe(on: MainScheduler.instance)
-            .subscribe(onNext: { [weak self] completed, fortune in
+            .subscribe(onNext: { [weak self] _ in
+                guard let self else { return }
+                isFortuneReady = true
+            })
+            .disposeOnDeactivate(interactor: self)
+            
+        userInfoFetchedSuccess
+            .observe(on: MainScheduler.instance)
+            .subscribe(onNext: { [weak self] _ in
+                guard let self else { return }
+                isUserInfoReady = true
+            })
+            .disposeOnDeactivate(interactor: self)
+        
+        // 미션 완료 시 로딩 관리
+        finishWithMissionComplete
+            .observe(on: MainScheduler.instance)
+            .subscribe(onNext: { [weak self] completed in
+                guard let self else { return }
+                
+                if isFortuneReady && isUserInfoReady {
+                    // 이미 모든 API가 완료된 경우 바로 운세 화면으로
+                    // (combineLatest에서 처리됨)
+                } else {
+                    // API가 아직 완료되지 않은 경우 로딩 표시
+                    router?.request(.showLoading)
+                }
+            })
+            .disposeOnDeactivate(interactor: self)
+        
+        Observable.combineLatest(finishWithMissionComplete, fortuneFetchedSuccess, userInfoFetchedSuccess)
+            .observe(on: MainScheduler.instance)
+            .subscribe(onNext: { [weak self] completed, fortune, userInfo in
                 guard let self else { return }
                 guard let fortuneInfo = UserDefaults.standard.dailyFortune() else {
+                    router?.request(.hideLoading)
                     listener?.request(.close)
                     return
                 }
@@ -120,9 +158,33 @@ final class RootInteractor: Interactor, RootInteractable {
                     newFortuneInfo.shouldShowCharm = isFirstAlarm && completed
                 }
                 UserDefaults.standard.setDailyFortune(info: newFortuneInfo)
-                goToFortune(fortune: fortune, fortuneInfo: newFortuneInfo)
+                
+                // 로딩 숨기고 운세 화면으로 이동
+                router?.request(.hideLoading)
+                router?.request(.routeToFortune(fortune, userInfo, newFortuneInfo))
             })
             .disposeOnDeactivate(interactor: self)
+            
+        // API 에러 처리
+        Observable.merge(
+            fortunePublisher.compactMap { result -> Error? in
+                if case .failure(let error) = result { return error }
+                return nil
+            },
+            userInfoPublisher.compactMap { result -> Error? in
+                if case .failure(let error) = result { return error }
+                return nil
+            }
+        )
+        .observe(on: MainScheduler.instance)
+        .subscribe(onNext: { [weak self] error in
+            guard let self else { return }
+            router?.request(.hideLoading)
+            debugPrint("API Error: \(error.localizedDescription)")
+            // 에러 발생 시 앱 종료
+            listener?.request(.close)
+        })
+        .disposeOnDeactivate(interactor: self)
     }
     
     private func getFortune(fortuneId: Int) {
@@ -144,16 +206,45 @@ final class RootInteractor: Interactor, RootInteractable {
         let request = APIRequest.Fortune.createFortune(userId: userId)
         APIClient.request(Fortune.self, request: request) { [weak self] fortune in
             guard let self else { return }
-            fortunePublisher.onNext(.success(fortune))
             let info = FortuneSaveInfo(
                 id: fortune.id,
                 shouldShowCharm: false,
                 charmIndex: nil
             )
             UserDefaults.standard.setDailyFortune(info: info)
+            fortunePublisher.onNext(.success(fortune))
         } failure: { [weak self] error in
             guard let self else { return }
             fortunePublisher.onNext(.failure(error))
+        }
+    }
+    
+    private func preloadAPIs() {
+        // 운세 API 호출
+        if let fortuneInfo = UserDefaults.standard.dailyFortune() {
+            getFortune(fortuneId: fortuneInfo.id)
+        } else {
+            createFortune()
+        }
+        
+        // UserInfo API 호출
+        preloadUserInfo()
+    }
+    
+    private func preloadUserInfo() {
+        guard let userId = Preference.userId else {
+            userInfoPublisher.onNext(.failure(FortuneError.userIdNotFound))
+            return
+        }
+        
+        let request = APIRequest.Users.getUser(userId: userId)
+        APIClient.request(UserInfoResponseDTO.self, request: request) { [weak self] userInfoDTO in
+            guard let self else { return }
+            let userInfo = userInfoDTO.toUserInfo()
+            userInfoPublisher.onNext(.success(userInfo))
+        } failure: { [weak self] error in
+            guard let self else { return }
+            userInfoPublisher.onNext(.failure(error))
         }
     }
 }
@@ -206,22 +297,6 @@ extension RootInteractor {
         }
     }
     
-    private func goToFortune(fortune: Fortune, fortuneInfo: FortuneSaveInfo) {
-        guard let userId = Preference.userId else { return }
-        APIClient.request(
-            UserInfoResponseDTO.self,
-            request: APIRequest.Users.getUser(userId: userId),
-            success: { [weak router] userInfo in
-                guard let router else { return }
-                let userInfoEntity = userInfo.toUserInfo()
-                DispatchQueue.main.async {
-                    router.request(.routeToFortune(fortune, userInfoEntity, fortuneInfo))
-                }
-            }) { error in
-                // 유저정보 획득 실패
-                debugPrint(error.localizedDescription)
-            }
-    }
 }
 
 // MARK: - FortuneListenerRequest

--- a/Projects/Feature/AlarmRelease/Feature/Sources/Root/RootInteractor.swift
+++ b/Projects/Feature/AlarmRelease/Feature/Sources/Root/RootInteractor.swift
@@ -47,6 +47,7 @@ public enum RootRouterRequest {
     case detachAlarmMission
     case routeToFortune(Fortune, UserInfo, FortuneSaveInfo)
     case detachFortune
+    case detachIntro
     case showLoading
     case hideLoading
 }
@@ -150,6 +151,7 @@ final class RootInteractor: Interactor, RootInteractable {
                 guard let self else { return }
                 guard let fortuneInfo = UserDefaults.standard.dailyFortune() else {
                     router?.request(.hideLoading)
+                    router?.request(.detachIntro)
                     listener?.request(.close)
                     return
                 }
@@ -182,6 +184,7 @@ final class RootInteractor: Interactor, RootInteractable {
             router?.request(.hideLoading)
             debugPrint("API Error: \(error.localizedDescription)")
             // 에러 발생 시 앱 종료
+            router?.request(.detachIntro)
             listener?.request(.close)
         })
         .disposeOnDeactivate(interactor: self)
@@ -309,6 +312,7 @@ extension RootInteractor {
             
             // 운세페이지 종료
             router?.request(.detachFortune)
+            router?.request(.detachIntro)
             listener?.request(.close)
         }
     }

--- a/Projects/Feature/AlarmRelease/Feature/Sources/Root/RootRouter.swift
+++ b/Projects/Feature/AlarmRelease/Feature/Sources/Root/RootRouter.swift
@@ -61,6 +61,8 @@ final class RootRouter: Router<RootInteractable>, RootRouting {
             routeToFortune(fortune: fortune, userInfo: userInfo, fortuneInfo: saveInfo)
         case .detachFortune:
             detachFortune()
+        case .detachIntro:
+            detachIntro()
         case .showLoading:
             showLoading()
         case .hideLoading:
@@ -166,6 +168,12 @@ final class RootRouter: Router<RootInteractable>, RootRouting {
     private func detachFortune() {
         guard let router = fortuneRouter else { return }
         fortuneRouter = nil
+        detachChild(router)
+    }
+    
+    private func detachIntro() {
+        guard let router = introRouter else { return }
+        self.introRouter = nil
         detachChild(router)
     }
     

--- a/Projects/Feature/AlarmRelease/Feature/Sources/Root/RootRouter.swift
+++ b/Projects/Feature/AlarmRelease/Feature/Sources/Root/RootRouter.swift
@@ -10,6 +10,7 @@ import RIBs
 import FeatureCommonEntity
 import FeatureAlarmMission
 import FeatureFortune
+import FeatureDesignSystem
 
 protocol RootInteractable: Interactable,
                            AlarmReleaseIntroListener,
@@ -60,6 +61,10 @@ final class RootRouter: Router<RootInteractable>, RootRouting {
             routeToFortune(fortune: fortune, userInfo: userInfo, fortuneInfo: saveInfo)
         case .detachFortune:
             detachFortune()
+        case .showLoading:
+            showLoading()
+        case .hideLoading:
+            hideLoading()
         }
     }
     
@@ -87,6 +92,7 @@ final class RootRouter: Router<RootInteractable>, RootRouting {
     
     private let fortuneBuilder: FortuneBuildable
     private var fortuneRouter: FortuneRouting?
+    
     
     private func presentOrPush(_ router: ViewableRouting) {
         let targetVC = router.viewControllable.uiviewController
@@ -161,5 +167,14 @@ final class RootRouter: Router<RootInteractable>, RootRouting {
         guard let router = fortuneRouter else { return }
         fortuneRouter = nil
         detachChild(router)
+    }
+    
+    // MARK: - Loading
+    private func showLoading() {
+        DSLoadingManager.shared.show()
+    }
+    
+    private func hideLoading() {
+        DSLoadingManager.shared.hide()
     }
 }

--- a/Projects/Feature/DesignSystem/Feature/Sources/Components/Loading/DSLoadingManager.swift
+++ b/Projects/Feature/DesignSystem/Feature/Sources/Components/Loading/DSLoadingManager.swift
@@ -1,0 +1,54 @@
+//
+//  DSLoadingManager.swift
+//  DesignSystem
+//
+//  Created by AI Assistant on 2/10/25.
+//
+
+import UIKit
+import SnapKit
+
+public final class DSLoadingManager {
+    public static let shared = DSLoadingManager()
+    
+    private var loadingView: DSDefaultLoadingView?
+    
+    private init() {}
+    
+    public func show() {
+        // 이미 로딩이 표시되고 있다면 무시
+        guard loadingView == nil else { return }
+        
+        // 키윈도우 찾기
+        guard let keyWindow = UIApplication.shared.connectedScenes
+            .compactMap({ $0 as? UIWindowScene })
+            .flatMap({ $0.windows })
+            .first(where: { $0.isKeyWindow }) else { return }
+        
+        // 로딩뷰 생성 및 키윈도우에 직접 추가
+        let loading = DSDefaultLoadingView()
+        keyWindow.addSubview(loading)
+        loading.snp.makeConstraints { make in
+            make.edges.equalToSuperview()
+        }
+        
+        // 참조 저장
+        loadingView = loading
+        
+        // 애니메이션 시작
+        loading.play()
+    }
+    
+    public func hide() {
+        guard let loading = loadingView else { return }
+        
+        // 애니메이션 정지
+        loading.stop()
+        
+        // 뷰 제거
+        loading.removeFromSuperview()
+        
+        // 참조 제거
+        loadingView = nil
+    }
+}


### PR DESCRIPTION
### 원인
- 운세 로드가 오래 걸릴 경우 사용자가 미션완료 또는 알람 해지 후부터 오래 기다려야함.

### 작업 내용
- 알람 해제화면 진입 부터 미리 운세를 로드하도록 함. 
- 운세화면 호출 떄까지 로드가 안됐을 경우, 로딩화면 보여주다가 완료될 때 이동하도록 수정